### PR TITLE
Add splitLines function and fix mistake in split signature

### DIFF
--- a/RFCs/FS-1033-extend-string-module.md
+++ b/RFCs/FS-1033-extend-string-module.md
@@ -60,7 +60,8 @@ Given the above considerations, the following functions are proposed to be added
 ```fsharp
 contains : string -> string -> bool 
 replace : string -> string -> string -> string 
-split : string -> string -> string seq
+split : string -> string -> string []
+splitLines : string -> string -> string []
 startsWith : string -> string -> bool
 endsWith : string -> string -> bool 
 trim : string -> string 


### PR DESCRIPTION
As mentioned in the RFC discussion, String.splitLines would also be great to have.

Additionally, those split functions should return ``string[]``, not ``string seq``.

Click “Files changed” → “⋯” → “View file” for the rendered RFC.
